### PR TITLE
feat: strip layout for minimal cloth tuning

### DIFF
--- a/BLOG_NOTES.md
+++ b/BLOG_NOTES.md
@@ -81,3 +81,4 @@ Web design feels clunky not because the medium is doomed, but because we’ve le
 - 2025-10-11: Added DOM integration specs covering capture/hide flow, resize refresh, and scheduler wake path.
 - 2025-10-12: README switched to npm commands for install/build/test so instructions match package-lock.- 2025-10-12: Added DOMToWebGL canonical mapping specs and cloth lifecycle regression tests.
 - 2025-10-12: Tuned pointer impulses via dataset overrides and canonical defaults; added specs verifying behaviour.
+- 2025-10-12: Simplified demo layout to h1+button, removed canvas double-scaling, and tuned tests to use minimal DOM.

--- a/PROGRESS_CHECKLIST.md
+++ b/PROGRESS_CHECKLIST.md
@@ -11,16 +11,15 @@
 - [x] Add mesh pooling / reactivation so elements can re-run the reveal without reload.
 - [x] Implement core physics unit tests (Verlet, collisions, sleep/wake).
 - [x] Wire simulation scheduler so only awake bodies tick.
-- [ ] Implement automated DOM-level integration tests (capture alignment, lifecycle).
-- [ ] Tune pointer impulse strength/radius per element and device type.
+- [x] Implement automated DOM-level integration tests (capture alignment, lifecycle).
+- [x] Tune pointer impulse strength/radius per element and device type.
 - [ ] Execute manual browser/network/memory QA passes and log findings.
 - [ ] Prep demo script + visuals showing the dual-layer architecture.
-- [ ] Build SimWorld (tests + implementation) with broad-phase wake logic.
 - [x] Build SimWorld (tests + implementation) with broad-phase wake logic.
 - [x] Introduce unified `applyImpulse(point, force)` API with coverage.
-- [ ] Retro-fit DOM/WebGL integration tests:
-  - [ ] Element pool lifecycle (prepare → mount → recycle → destroy)
-  - [ ] Static mesh alignment & resize/scroll sync
-  - [ ] Cloth-enabled DOM hiding and mesh replacement
-  - [ ] Canonical UI render mapping
-  - [ ] Cloth lifecycle (dormant → active → reset)
+- [x] Retro-fit DOM/WebGL integration tests:
+  - [x] Element pool lifecycle (prepare → mount → recycle → destroy)
+  - [x] Static mesh alignment & resize/scroll sync
+  - [x] Cloth-enabled DOM hiding and mesh replacement
+  - [x] Canonical UI render mapping
+  - [x] Cloth lifecycle (dormant → active → reset)

--- a/src/App.css
+++ b/src/App.css
@@ -1,336 +1,40 @@
-.app-shell {
-  display: flex;
-  flex-direction: column;
-  gap: 56px;
-  padding: 48px clamp(24px, 5vw, 72px) 96px;
-  max-width: 1160px;
-  margin: 0 auto;
-}
-
-.site-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  font-size: 0.9rem;
-  padding: 10px 16px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(17, 24, 39, 0.08);
-  box-shadow: 0 20px 40px rgba(79, 70, 229, 0.07);
-}
-
-.brand__mark {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, #818cf8, #c084fc);
-  color: #fff;
-  font-weight: 700;
-}
-
-.site-nav {
-  display: flex;
-  gap: clamp(16px, 3vw, 36px);
-  font-size: 0.95rem;
-}
-
-.nav-link {
-  position: relative;
-  padding-bottom: 4px;
-}
-
-.nav-link::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 2px;
-  background: linear-gradient(90deg, #6366f1, #ec4899);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 220ms ease;
-}
-
-.nav-link:focus-visible::after,
-.nav-link:hover::after {
-  transform: scaleX(1);
-}
-
-.hero {
+.demo-shell {
+  min-height: 100vh;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: clamp(32px, 6vw, 56px);
-  align-items: end;
+  place-content: center;
+  gap: 24px;
+  padding: 48px 24px;
+  text-align: center;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #111827;
+  background: radial-gradient(circle at top, #eef2ff 0%, #f8fafc 100%);
 }
 
-.hero__content {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.hero__headline {
-  font-size: clamp(2.4rem, 4vw, 3.5rem);
-  line-height: 1.1;
+.demo-title {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
   margin: 0;
 }
 
-.hero__body {
+.demo-copy {
   margin: 0;
-  color: #4b5563;
   max-width: 520px;
+  justify-self: center;
+  color: #4b5563;
 }
 
-.hero__tag-inline {
-  margin-left: 6px;
-  padding: 2px 10px;
+.demo-button {
+  padding: 16px 32px;
+  font-size: 1rem;
   border-radius: 999px;
-  background: rgba(99, 102, 241, 0.12);
-  color: #3730a3;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-}
-
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 12px 22px;
-  border-radius: 999px;
-  font-size: 0.95rem;
-  font-weight: 600;
-  border: 1px solid transparent;
-  transition: transform 180ms ease, box-shadow 200ms ease;
-}
-
-.button:focus-visible,
-.button:hover {
-  transform: translateY(-2px);
-}
-
-.button--primary {
-  background: linear-gradient(135deg, #4f46e5, #ec4899);
+  border: 0;
+  cursor: pointer;
+  background: linear-gradient(135deg, #6366f1, #ec4899);
   color: #fff;
-  box-shadow: 0 20px 30px rgba(79, 70, 229, 0.18);
-}
-
-.button--ghost {
-  background: rgba(255, 255, 255, 0.7);
-  border-color: rgba(17, 24, 39, 0.1);
-  color: #1f2937;
-}
-
-.hero__aside {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.hero__callout {
-  padding: 24px;
-  border-radius: 28px;
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(99, 102, 241, 0.15);
-  box-shadow: 0 36px 80px rgba(14, 116, 144, 0.1);
-  max-width: 320px;
-  display: grid;
-  gap: 8px;
-}
-
-.callout__eyebrow {
-  margin: 0;
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #6366f1;
-}
-
-.callout__body {
-  margin: 0;
-  color: #1f2937;
-}
-
-.eyebrow {
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: #818cf8;
   font-weight: 600;
+  transition: transform 180ms ease;
 }
 
-.section {
-  display: grid;
-  gap: 32px;
-}
-
-.section__header {
-  display: grid;
-  gap: 12px;
-  max-width: 560px;
-}
-
-.section__title {
-  font-size: clamp(1.8rem, 3vw, 2.3rem);
-  margin: 0;
-}
-
-.cards-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: clamp(20px, 3vw, 32px);
-}
-
-.card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  padding: 28px;
-  border-radius: 32px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  box-shadow: 0 30px 60px rgba(148, 163, 184, 0.25);
-}
-
-.card h3 {
-  margin: 0;
-  font-size: 1.32rem;
-}
-
-.card p {
-  margin: 0;
-  color: #4b5563;
-}
-
-.pill-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  padding: 0;
-  margin: 16px 0 0;
-  list-style: none;
-}
-
-.pill {
-  padding: 4px 12px;
-  border-radius: 999px;
-  background: rgba(226, 232, 240, 0.9);
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: #1f2937;
-}
-
-.card__link {
-  font-weight: 600;
-  color: #4338ca;
-  width: fit-content;
-}
-
-.timeline {
-  display: grid;
-  gap: 20px;
-}
-
-.timeline__item {
-  padding: 24px 28px;
-  border-radius: 28px;
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid rgba(129, 140, 248, 0.25);
-  box-shadow: 0 18px 42px rgba(99, 102, 241, 0.18);
-}
-
-.timeline__eyebrow {
-  margin: 0 0 6px;
-  font-size: 0.78rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #64748b;
-  font-weight: 600;
-}
-
-.timeline__title {
-  margin: 0 0 8px;
-  font-size: 1.15rem;
-}
-
-.timeline__body {
-  margin: 0;
-  color: #475569;
-}
-
-.footer {
-  display: grid;
-  gap: 24px;
-  padding-top: 40px;
-  border-top: 1px solid rgba(148, 163, 184, 0.3);
-}
-
-.footer__content {
-  display: grid;
-  gap: 12px;
-  padding: 32px;
-  border-radius: 32px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(129, 140, 248, 0.2);
-  box-shadow: 0 25px 55px rgba(15, 118, 110, 0.16);
-}
-
-.footer__content h2 {
-  margin: 0;
-  font-size: clamp(1.6rem, 3vw, 2.1rem);
-}
-
-.footer__content p {
-  margin: 0;
-  color: #4b5563;
-}
-
-.footer__link {
-  color: #4338ca;
-  font-weight: 600;
-}
-
-.footer__note {
-  margin: 0;
-  color: #6b7280;
-  font-size: 0.85rem;
-}
-
-.cloth-enabled {
-  position: relative;
-  isolation: isolate;
-  accent-color: #6366f1;
-}
-
-@media (max-width: 720px) {
-  .site-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .hero__actions {
-    width: 100%;
-  }
-
-  .button {
-    flex: 1;
-  }
+.demo-button:hover,
+.demo-button:focus-visible {
+  transform: translateY(-2px);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,51 +2,6 @@ import { useEffect } from 'react'
 import './App.css'
 import { PortfolioWebGL } from './lib/portfolioWebGL'
 
-const projects = [
-  {
-    title: 'WebGL Wonderwall',
-    description:
-      'A gallery that wraps brand illustrations onto animated cloth banners hanging from a virtual ceiling.',
-    href: '#project-wonderwall',
-    tags: ['Three.js', 'Creative Coding'],
-  },
-  {
-    title: 'Soft UI Playground',
-    description:
-      'Micro-interactions that respond with elastic simulations to cursor and scroll input.',
-    href: '#project-soft-ui',
-    tags: ['Motion', 'Experimental UX'],
-  },
-  {
-    title: 'Threaded Storytelling',
-    description:
-      'Narrative case study where copy, imagery, and audio feel stitched together with real-time physics.',
-    href: '#project-threaded',
-    tags: ['Narrative', 'Web Audio'],
-  },
-]
-
-const milestones = [
-  {
-    eyebrow: '2024 – Present',
-    title: 'Principal Creative Technologist · Arcadia Studio',
-    description:
-      'Leading prototypes that blend tactile physics with brand storytelling for luxury clients.',
-  },
-  {
-    eyebrow: '2022 – 2024',
-    title: 'Senior Frontend Engineer · Playground Labs',
-    description:
-      'Built immersive marketing sites with performance budgets under 200kb and 60fps targets.',
-  },
-  {
-    eyebrow: '2019 – 2022',
-    title: 'Interactive Developer · Indie Interactive',
-    description:
-      'Shipped award-winning WebGL experiments featured on Awwwards and CSS Design Awards.',
-  },
-]
-
 function App() {
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -60,124 +15,16 @@ function App() {
   }, [])
 
   return (
-    <div className="app-shell">
-      <header className="site-header">
-        <div className="brand cloth-enabled" aria-hidden="true">
-          <span className="brand__mark">JC</span>
-          <span className="brand__text">Cloth Portfolio</span>
-        </div>
-        <nav className="site-nav" aria-label="Primary">
-          <a className="nav-link cloth-enabled" href="#projects">
-            Projects
-          </a>
-          <a className="nav-link cloth-enabled" href="#process">
-            Process
-          </a>
-          <a className="nav-link cloth-enabled" href="#contact">
-            Contact
-          </a>
-        </nav>
-      </header>
-
-      <main>
-        <section className="hero" id="intro">
-          <div className="hero__content">
-            <p className="eyebrow">Creative Web Technologist</p>
-            <h1 className="hero__headline cloth-enabled">
-              Tactile web experiences that feel alive in your hands.
-            </h1>
-            <p className="hero__body">
-              I craft portfolio-worthy experiments that pair traditional layout with
-              unexpected cloth physics. Hover, drag, or tap anything tagged with
-              <span className="hero__tag-inline">cloth-enabled</span> to see the
-              fabric peel back.
-            </p>
-            <div className="hero__actions">
-              <a className="button button--primary cloth-enabled" href="#projects">
-                See Work
-              </a>
-              <a className="button button--ghost cloth-enabled" href="#contact">
-                Book a Prototype Session
-              </a>
-            </div>
-          </div>
-          <aside className="hero__aside">
-            <div className="hero__callout cloth-enabled">
-              <p className="callout__eyebrow">Next Prototype</p>
-              <p className="callout__body">
-                A WebGL moodboard that drapes your typography over reactive fabric.
-              </p>
-            </div>
-          </aside>
-        </section>
-
-        <section className="section" id="projects">
-          <div className="section__header">
-            <p className="eyebrow">Selected Work</p>
-            <h2 className="section__title">Projects staged for the cloth reveal</h2>
-          </div>
-          <div className="cards-grid">
-            {projects.map((project) => (
-              <article className="card cloth-enabled" key={project.title}>
-                <div className="card__content">
-                  <h3 id={project.href.replace('#', '')}>{project.title}</h3>
-                  <p>{project.description}</p>
-                  <ul className="pill-list" aria-label="Tags">
-                    {project.tags.map((tag) => (
-                      <li className="pill" key={tag}>
-                        {tag}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <a className="card__link" href={project.href}>
-                  View case study
-                </a>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="section" id="process">
-          <div className="section__header">
-            <p className="eyebrow">Process</p>
-            <h2 className="section__title">How the cloth illusion comes together</h2>
-          </div>
-          <div className="timeline">
-            {milestones.map((item) => (
-              <div className="timeline__item cloth-enabled" key={item.title}>
-                <p className="timeline__eyebrow">{item.eyebrow}</p>
-                <h3 className="timeline__title">{item.title}</h3>
-                <p className="timeline__body">{item.description}</p>
-              </div>
-            ))}
-          </div>
-        </section>
-      </main>
-
-      <footer className="footer" id="contact">
-        <div className="footer__content cloth-enabled">
-          <h2>Let&apos;s stitch something together</h2>
-          <p>
-            I&apos;m currently open for collaborations and prototyping engagements.
-            Drop a note at
-            <a className="footer__link" href="mailto:james@cloth.dev">
-              james@cloth.dev
-            </a>
-            or find me on{' '}
-            <a className="footer__link" href="https://twitter.com" target="_blank" rel="noreferrer">
-              Twitter
-            </a>{' '}
-            and{' '}
-            <a className="footer__link" href="https://www.linkedin.com" target="_blank" rel="noreferrer">
-              LinkedIn
-            </a>
-            .
-          </p>
-        </div>
-        <p className="footer__note">© {new Date().getFullYear()} James Cloth. Built for experiments.</p>
-      </footer>
-    </div>
+    <main className="demo-shell">
+      <h1 className="demo-title">Cloth Playground</h1>
+      <p className="demo-copy">
+        This minimal scene keeps the DOM simple while we tune the cloth overlay.
+        Click the button below to peel it away.
+      </p>
+      <button className="demo-button cloth-enabled" type="button">
+        Peel Back
+      </button>
+    </main>
   )
 }
 

--- a/src/lib/__tests__/domIntegration.test.ts
+++ b/src/lib/__tests__/domIntegration.test.ts
@@ -224,11 +224,10 @@ beforeEach(() => {
   rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockReturnValue(1 as any)
   cafSpy = vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
   document.body.innerHTML = `
-    <div class="wrapper">
-      <button id="cta" class="cloth-enabled">Click me</button>
-      <div id="static">Static content</div>
-      <a id="link" class="cloth-enabled">Link</a>
-    </div>
+    <main class="demo">
+      <h1>Tactile demo</h1>
+      <button id="cta" class="cloth-enabled">Peel Back</button>
+    </main>
   `
   ;(document.getElementById('cta') as HTMLElement).getBoundingClientRect = () => ({
     left: 100,
@@ -239,17 +238,6 @@ beforeEach(() => {
     height: 60,
     x: 100,
     y: 200,
-    toJSON() {},
-  })
-  ;(document.getElementById('link') as HTMLElement).getBoundingClientRect = () => ({
-    left: 400,
-    top: 100,
-    right: 460,
-    bottom: 140,
-    width: 60,
-    height: 40,
-    x: 400,
-    y: 100,
     toJSON() {},
   })
 })
@@ -267,8 +255,9 @@ describe('PortfolioWebGL DOM integration', () => {
 
     const clothElements = Array.from(document.querySelectorAll<HTMLElement>('.cloth-enabled'))
 
-    expect(poolMocks.prepare).toHaveBeenCalledTimes(clothElements.length)
-    expect(poolMocks.mount).toHaveBeenCalledTimes(clothElements.length)
+    expect(clothElements).toHaveLength(1)
+    expect(poolMocks.prepare).toHaveBeenCalledTimes(1)
+    expect(poolMocks.mount).toHaveBeenCalledTimes(1)
     clothElements.forEach((el) => {
       expect(el.style.opacity).toBe('0')
     })
@@ -318,12 +307,7 @@ describe('PortfolioWebGL DOM integration', () => {
 
     const adapter = schedulerMocks.addBody.mock.calls[0][0]
     const cloth = clothMocks.instances[0]
-    const pointer = (webgl as any).pointer as {
-      position: THREE.Vector2
-      previous: THREE.Vector2
-      velocity: THREE.Vector2
-      needsImpulse: boolean
-    }
+    const pointer = (webgl as any).pointer as any
 
     pointer.previous.set(0, 0)
     pointer.position.set(0.2, 0.1)
@@ -354,11 +338,7 @@ describe('PortfolioWebGL DOM integration', () => {
     button.dispatchEvent(new MouseEvent('click'))
     const adapter = schedulerMocks.addBody.mock.calls[0][0]
     const cloth = clothMocks.instances[0]
-    const pointer = (webgl as any).pointer as THREE.Vector2 & {
-      previous: THREE.Vector2
-      velocity: THREE.Vector2
-      needsImpulse: boolean
-    }
+    const pointer = (webgl as any).pointer as any
 
     pointer.previous.set(0, 0)
     pointer.position.set(0.3, 0.2)

--- a/src/lib/__tests__/domToWebGL.test.ts
+++ b/src/lib/__tests__/domToWebGL.test.ts
@@ -106,7 +106,6 @@ import { DOMToWebGL } from '../domToWebGL'
 import {
   CANONICAL_HEIGHT_METERS,
   CANONICAL_WIDTH_METERS,
-  computeViewportScale,
   toCanonicalHeightMeters,
   toCanonicalWidthMeters,
   toCanonicalX,
@@ -180,17 +179,15 @@ describe('DOMToWebGL canonical mapping', () => {
   it('updates root group scale when resizing the viewport', () => {
     const dom = new DOMToWebGL(document.body)
     const rootGroup = (dom as any).rootGroup as { scale: { x: number; y: number } }
-    const initialScale = computeViewportScale(window.innerWidth, window.innerHeight)
-    expect(rootGroup.scale.x).toBeCloseTo(initialScale.scaleX)
-    expect(rootGroup.scale.y).toBeCloseTo(initialScale.scaleY)
+    expect(rootGroup.scale.x).toBe(1)
+    expect(rootGroup.scale.y).toBe(1)
 
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 })
     Object.defineProperty(window, 'innerHeight', { configurable: true, value: 600 })
     dom.resize()
 
-    const updatedScale = computeViewportScale(window.innerWidth, window.innerHeight)
-    expect(rootGroup.scale.x).toBeCloseTo(updatedScale.scaleX)
-    expect(rootGroup.scale.y).toBeCloseTo(updatedScale.scaleY)
+    expect(rootGroup.scale.x).toBe(1)
+    expect(rootGroup.scale.y).toBe(1)
 
     dom.detach()
   })

--- a/src/lib/domToWebGL.ts
+++ b/src/lib/domToWebGL.ts
@@ -2,7 +2,6 @@ import * as THREE from 'three'
 import {
   CANONICAL_HEIGHT_METERS,
   CANONICAL_WIDTH_METERS,
-  computeViewportScale,
   fromPointerToCanonical,
   toCanonicalHeightMeters,
   toCanonicalWidthMeters,
@@ -27,7 +26,6 @@ export class DOMToWebGL {
 
   private container: HTMLElement
   private html2canvasRef: typeof import('html2canvas')['default'] | null = null
-  private rootGroup: THREE.Group
   private viewportWidth: number
   private viewportHeight: number
 
@@ -54,7 +52,6 @@ export class DOMToWebGL {
     this.scene.add(this.rootGroup)
 
     this.updateCamera()
-    this.updateRootScale()
     this.attach()
   }
 
@@ -74,7 +71,6 @@ export class DOMToWebGL {
     this.viewportWidth = window.innerWidth
     this.viewportHeight = window.innerHeight
     this.renderer.setSize(this.viewportWidth, this.viewportHeight)
-    this.updateRootScale()
   }
 
   render() {
@@ -186,11 +182,6 @@ export class DOMToWebGL {
     const x = toCanonicalX(centerX, this.viewportWidth)
     const y = toCanonicalY(centerY, this.viewportHeight)
     return [x, y, 0]
-  }
-
-  private updateRootScale() {
-    const { scaleX, scaleY } = computeViewportScale(this.viewportWidth, this.viewportHeight)
-    this.rootGroup.scale.set(scaleX, scaleY, 1)
   }
 
   private async ensureHtml2Canvas() {


### PR DESCRIPTION
## Summary
- replace the complex portfolio layout with a minimal h1/button scene
- drop redundant root scaling in DOMToWebGL to fix double-size snapshots
- update tests and notes to reflect the simplified demo