### PR TITLE
PR A — Wireframe overlay + glyph legend + Events panel v2 (PROJECT: Newton)

### DIFF
--- a/src/app/__tests__/eventsPanel.spec.tsx
+++ b/src/app/__tests__/eventsPanel.spec.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+
+// Spec for PR A: non-modal Events panel, toggled by Cmd/Ctrl+E, opens at ~45% height and supports fullscreen
+// This is a placeholder failing test to drive implementation.
+
+describe('Events panel (spec)', () => {
+  it('toggles with Cmd/Ctrl+E and is non-modal (scene remains interactive)', async () => {
+    const nonModalEventsPanel = false
+    expect(nonModalEventsPanel).toBe(true)
+  })
+})
+

--- a/src/engine/render/__tests__/overlayWireframe.spec.ts
+++ b/src/engine/render/__tests__/overlayWireframe.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+
+// Spec for PR A: wireframe overlay pass draws on top of solids
+// Failing test (tests-first): after activating a cloth, a dedicated wireframe overlay (line segments) exists
+
+describe('Wireframe overlay (spec)', () => {
+  it('draws an overlay wireframe above solid meshes after activation', async () => {
+    // Pseudo-spec: activate one cloth element and assert a wireframe overlay pass exists
+    // This is intentionally failing until PR A lands the overlay system.
+    const overlayWireframeExists = false
+    expect(overlayWireframeExists).toBe(true)
+  })
+})
+


### PR DESCRIPTION
Implements tests-first spec for PR A. This PR currently adds failing tests to drive implementation.\n\n- overlayWireframe.spec: asserts a dedicated wireframe overlay pass renders above solid meshes after activation\n- eventsPanel.spec: asserts a non‑modal Events panel toggled via Cmd/Ctrl+E that opens docked (~45%) with fullscreen toggle\n\nCloses #33